### PR TITLE
Add equals sign alignment rule to phpcs.xml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,6 @@ LICENSE.md export-ignore
 LICENSE.txt export-ignore
 README.md export-ignore
 .vscode-upload.json export-ignore
+
+# Opt out of AI model training
+* ai-training=false

--- a/README-PHPCS.md
+++ b/README-PHPCS.md
@@ -1,0 +1,82 @@
+# PHP CodeSniffer Configuration for MainWP Child
+
+This repository includes a PHP_CodeSniffer (PHPCS) configuration file (`phpcs.xml`) that helps maintain consistent code style across the MainWP Child plugin codebase.
+
+## Features
+
+The PHPCS configuration includes rules for:
+
+- **Equals Sign Alignment**: Ensures consistent spacing around equals signs in assignments
+- **Indentation**: Uses 4 spaces for indentation (no tabs)
+- **Yoda Conditions**: Enforces Yoda conditions for comparisons
+- **Line Endings**: Ensures consistent line endings
+- **Comment Punctuation**: Enforces proper punctuation in comments
+
+## Usage
+
+### Installing PHP_CodeSniffer
+
+If you don't have PHP_CodeSniffer installed, you can install it globally using Composer:
+
+```bash
+composer global require squizlabs/php_codesniffer
+```
+
+Or locally in your project:
+
+```bash
+composer require --dev squizlabs/php_codesniffer
+```
+
+### Running PHPCS to Check Code Style
+
+To check your code against the coding standards:
+
+```bash
+# Using global installation
+phpcs --standard=phpcs.xml path/to/files
+
+# Using local installation
+vendor/bin/phpcs --standard=phpcs.xml path/to/files
+```
+
+### Running PHPCBF to Automatically Fix Issues
+
+To automatically fix many coding standard violations:
+
+```bash
+# Using global installation
+phpcbf --standard=phpcs.xml path/to/files
+
+# Using local installation
+vendor/bin/phpcbf --standard=phpcs.xml path/to/files
+```
+
+## Common Use Cases
+
+### Fix Equals Sign Alignment Issues
+
+One of the most common issues is equals sign alignment. To fix these issues across the codebase:
+
+```bash
+phpcbf --standard=phpcs.xml .
+```
+
+### Check a Specific File or Directory
+
+```bash
+phpcs --standard=phpcs.xml class/class-mainwp-child.php
+phpcs --standard=phpcs.xml class/
+```
+
+## Integration with IDEs
+
+Many IDEs support PHP_CodeSniffer integration, allowing you to see coding standard violations directly in your editor:
+
+- **PhpStorm**: Go to Settings → PHP → Quality Tools → PHP_CodeSniffer and configure the path to phpcs. Then in Editor → Inspections, enable PHP → Quality Tools → PHP_CodeSniffer validation.
+- **Visual Studio Code**: Install the "PHP Sniffer & Beautifier" extension.
+- **Sublime Text**: Install the "SublimeLinter-phpcs" package.
+
+## Contributing
+
+When contributing to the MainWP Child plugin, please ensure your code follows these coding standards. Running PHPCBF before submitting a pull request can help catch and fix many common issues automatically.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -55,4 +55,14 @@
 
 	<rule ref="Generic.WhiteSpace.DisallowTabIndent" />
 
+	<!-- Align equals signs in multiple adjacent assignments -->
+	<rule ref="Generic.Formatting.MultipleStatementAlignment">
+		<properties>
+			<!-- Only require minimal alignment for equals signs -->
+			<property name="maxPadding" value="1" />
+			<!-- Make it a warning rather than an error -->
+			<property name="error" value="false" />
+		</properties>
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
## Description

This PR adds the `Generic.Formatting.MultipleStatementAlignment` rule to the existing `phpcs.xml` configuration file to help maintain consistent equals sign alignment across the codebase. It also includes a detailed README-PHPCS.md file with instructions on how to use PHP_CodeSniffer and PHPCBF to check and fix code style issues.

## Changes

- Added `Generic.Formatting.MultipleStatementAlignment` rule to `phpcs.xml`
- Set `maxPadding` to 1 to ensure consistent spacing around equals signs
- Set `error` to false to make it a warning rather than an error
- Added README-PHPCS.md with detailed instructions on using PHPCS/PHPCBF

## Benefits

- Helps maintain consistent code style across the codebase
- Prevents future equals sign alignment issues
- Makes it easier for contributors to check and fix code style issues
- Reduces the need for manual code style fixes in PRs

## Testing

To test this change, you can run:

```bash
phpcs --standard=phpcs.xml path/to/files
phpcbf --standard=phpcs.xml path/to/files
```

These commands will check and fix code style issues according to the updated configuration.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new README file detailing PHP_CodeSniffer configuration and usage instructions, including IDE integration and contributor guidelines.
- **Style**
  - Updated code style rules to enforce minimal alignment of equals signs in assignment statements, with violations set as warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->